### PR TITLE
Fix milk clay bucket not having capability

### DIFF
--- a/src/main/java/knightminer/ceramics/items/MilkClayBucketItem.java
+++ b/src/main/java/knightminer/ceramics/items/MilkClayBucketItem.java
@@ -1,6 +1,8 @@
 package knightminer.ceramics.items;
 
+import knightminer.ceramics.util.FluidClayBucketWrapper;
 import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
@@ -15,6 +17,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Clay bucket holding milk
@@ -29,6 +33,11 @@ public class MilkClayBucketItem extends BaseClayBucketItem {
   public InteractionResultHolder<ItemStack> use(Level worldIn, Player player, InteractionHand hand) {
     player.startUsingItem(hand);
     return new InteractionResultHolder<>(InteractionResult.SUCCESS, player.getItemInHand(hand));
+  }
+
+  @Override
+  public @Nullable ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
+    return new FluidClayBucketWrapper(stack);
   }
 
   @Override


### PR DESCRIPTION
All of FluidClayBucketWrapper already had support for the milk bucket, it just wasn't initialised. Looks like it was removed from the base bucket class in 2c8a4918c9381fcdb5128abe1d569050dfca4ad9 and mistakenly not added back to the milk one.
Result was that it could be filled by capability, but not drained.